### PR TITLE
修正 docker 镜像问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG GOPROXY=https://goproxy.cn,direct
 RUN cd /app && \
     go build -o /medalhelper /app
 
-FROM scratch
+FROM gcr.io/distroless/static
 COPY --from=builder /medalhelper /medalhelper
 WORKDIR /config
 ENTRYPOINT ["/medalhelper"]

--- a/README.md
+++ b/README.md
@@ -50,12 +50,17 @@ docker run --rm -ti medalhelper login
 
 > 填写配置文件 users.yaml
 
-参考下文编辑 `users.yaml`。
+参考下文编辑 `users.yaml`。注意 `CRON` 中填写的时间，时区需要使用环境变量 `TZ` 指定。
 
 > 运行
 
 ```shell
-docker run -d -v $(pwd)/users.yaml:/config/users.yaml --restart unless-stopped --name medalhelper medalhelper
+docker run -d \
+    -e TZ=Asia/Shanghai
+    -v $(pwd)/users.yaml:/config/users.yaml \
+    --restart unless-stopped \
+    --name medalhelper \
+    medalhelper
 ```
 
 > 查看日志


### PR DESCRIPTION
scratch 空镜像要手动处理时区数据和 SSL CA，更换为 distroless 了。README 加入 docker 运行指定时区的参数。