### PR TITLE
[Doc]: Add '-' to cmd args 'login' and 'start'

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -23,7 +23,7 @@ docker build -t medalhelper .
 > 获取 B 站账号的 access_key
 
 ```shell
-docker run --rm -ti -v $(pwd)/users.yaml:/config/users.yaml medalhelper login
+docker run --rm -ti -v $(pwd)/users.yaml:/config/users.yaml medalhelper -login
 ```
 
 按提示回车并扫码（或访问 URL），得到 `access_key`。
@@ -51,7 +51,7 @@ docker run -d \
     -v $(pwd)/users.yaml:/config/users.yaml \
     --restart unless-stopped \
     --name medalhelper \
-    medalhelper start
+    medalhelper -start
 ```
 
 > 查看日志
@@ -74,7 +74,7 @@ cd MedalHelper
 > 获取 B 站账号的 access_key
 
 ```shell
-go run main.go login
+go run main.go -login
 ```
 扫码登录，会得到 `access_key` 即可
 
@@ -94,7 +94,7 @@ go run main.go
 > 无视定时任务立刻运行一次
 
 ```shell
-go run main.go start
+go run main.go -start
 ```
 
 ### 配置文件


### PR DESCRIPTION
## Describe your changes
修改了文档中的一些命令，在`start`和`login`这两个命令行参数前面加上`-`。
我查阅了`flag`库的官方文档 <https://pkg.go.dev/flag@go1.16#hdr-Command_line_flag_syntax>，flag只支持以下几种参数格式：
```
-flag
--flag   // double dashes are also permitted
-flag=x
-flag x  // non-boolean flags only
```
docker和直接运行编译后的可执行文件我也试了，不加`-`的参数是无效的。

## Issue ticket number and link
None
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
